### PR TITLE
Use HTTPS for WOWDB tooltip js

### DIFF
--- a/engine/report/sc_report_html_sim.cpp
+++ b/engine/report/sc_report_html_sim.cpp
@@ -1440,7 +1440,7 @@ void print_html_( report::sc_html_stream& os, sim_t& sim )
   if ( sim.decorated_tooltips )
   {
     os << "<script type=\"text/javascript\" "
-          "src=\"http://static-azeroth.cursecdn.com/current/js/syndication/"
+          "src=\"https://static-azeroth.cursecdn.com/current/js/syndication/"
           "tt.js\"></script>\n";
   }
 


### PR DESCRIPTION
Since the WOWDB tooltip js is served over HTTPS there is no reason to use HTTP.

This fixes Chromes Mixed Content errors if the report is served over HTTPS.